### PR TITLE
Add @types/node and typescript devDependencies to CLI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "commander": "^14.0.1",
     "axios": "^1.12.2"
   },
-  "peerDependencies": {
-    "typescript": ">=5.0.0"
+  "devDependencies": {
+    "@types/node": "^22.18.8",
+    "typescript": "^5.9.3"
   },
   "keywords": [
     "gatekit",


### PR DESCRIPTION
## Summary

Fixed missing TypeScript development dependencies in the CLI package to enable proper TypeScript compilation and Node.js type checking.

**Version**: v1.2.1
**Source**: [1a11c6e](https://github.com/filipexyz/gatekit/commit/1a11c6e)

### Changes

- **Added devDependencies**: Moved TypeScript tooling from peerDependencies to devDependencies
  - : ^22.18.8 (Node.js type definitions)
  - : ^5.9.3 (TypeScript compiler)
- **Removed peerDependencies**: Eliminated the typescript peerDependency requirement

### Impact

This change ensures the CLI package can be built and developed without requiring users to install TypeScript globally or as a peer dependency, improving the developer experience and build reliability.
