### PR TITLE
Update CLI to use latest SDK version instead of pinned version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@gatekit/sdk": "^1.2.2",
+    "@gatekit/sdk": "latest",
     "commander": "^14.0.1",
     "axios": "^1.12.2"
   },


### PR DESCRIPTION
## Summary

Updates the CLI package to use the latest version of  instead of a pinned version, ensuring the CLI always uses the most current SDK features and fixes.

**Version**: v1.2.2
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **Dependency Update**: Changed  from  to 
  - Ensures CLI automatically picks up new SDK releases
  - Eliminates version sync issues between CLI and SDK
  - Provides users with latest API features and bug fixes

### Benefits

- **Automatic Updates**: CLI users get latest SDK improvements without waiting for CLI releases
- **Reduced Maintenance**: No need to manually bump SDK versions in CLI package
- **Better User Experience**: Latest features and fixes available immediately
