### PR TITLE
Add authentication commands and email platform options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,19 @@ gatekit keys revoke --keyId "key-123"
 
 ## Auth
 
+### Create a new user account (first user becomes admin)
+```bash
+gatekit auth signup --email admin@example.com --password Admin123 --name "Admin User"
+```
+
+### Login with email and password
+```bash
+gatekit auth login --email admin@example.com --password Admin123
+```
+
 ### Get current authentication context and permissions
 ```bash
-gatekit auth whoami --help
+gatekit auth whoami
 ```
 
 ## Identities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/cli",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Official CLI for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "bin": {
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "echo \"No tests for generated CLI - tested in backend\"",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/src/commands/api-keys.ts
+++ b/src/commands/api-keys.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createApikeysCommand(): Command {
   const apikeys = new Command('api-keys');
 
@@ -125,67 +126,6 @@ export function createApikeysCommand(): Command {
   return apikeys;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/members.ts
+++ b/src/commands/members.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createMembersCommand(): Command {
   const members = new Command('members');
 
@@ -127,67 +128,6 @@ export function createMembersCommand(): Command {
   return members;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -4,6 +4,7 @@
 import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
+import { buildMessageDto } from '../lib/message-utils';
 
 export function createMessagesCommand(): Command {
   const messages = new Command('messages');
@@ -23,6 +24,10 @@ export function createMessagesCommand(): Command {
     .option('--raw <value>', 'Include raw platform message data', 'false')
     .option('--reactions <value>', 'Include reactions on each message', 'false')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -62,6 +67,10 @@ export function createMessagesCommand(): Command {
     .command('stats')
     .description('Get message statistics for a project')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -89,6 +98,10 @@ export function createMessagesCommand(): Command {
     .description('Get a specific message by ID')
     .option('--messageId <value>', 'Message ID')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -116,6 +129,10 @@ export function createMessagesCommand(): Command {
     .description('Delete messages older than specified days')
     .option('--daysBefore <value>', 'Delete messages older than this many days')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -148,6 +165,10 @@ export function createMessagesCommand(): Command {
     .option('--options <value>', 'Message options')
     .option('--metadata <value>', 'Message metadata')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -175,6 +196,10 @@ export function createMessagesCommand(): Command {
     .description('Check message delivery status')
     .option('--jobId <value>', 'Message job ID')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -202,6 +227,10 @@ export function createMessagesCommand(): Command {
     .description('Retry a failed message')
     .option('--jobId <value>', 'Failed message job ID')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -232,6 +261,10 @@ export function createMessagesCommand(): Command {
     .option('--limit <value>', 'Number of messages to return', '50')
     .option('--offset <value>', 'Number of messages to skip', '0')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -261,6 +294,10 @@ export function createMessagesCommand(): Command {
     .option('--messageId <value>', 'Message ID to react to')
     .option('--emoji <value>', 'Emoji to react with (e.g., "👍", "❤️")')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -295,6 +332,10 @@ export function createMessagesCommand(): Command {
     .option('--messageId <value>', 'Message ID to unreact from')
     .option('--emoji <value>', 'Emoji to remove (e.g., "👍", "❤️")')
     .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -325,67 +366,6 @@ export function createMessagesCommand(): Command {
   return messages;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/platform-logs.ts
+++ b/src/commands/platform-logs.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createPlatformLogsCommand(): Command {
   const platformLogs = new Command('platform-logs');
 
@@ -103,67 +104,6 @@ export function createPlatformLogsCommand(): Command {
   return platformLogs;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/platforms.ts
+++ b/src/commands/platforms.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createPlatformsCommand(): Command {
   const platforms = new Command('platforms');
 
@@ -246,67 +247,6 @@ export function createPlatformsCommand(): Command {
   return platforms;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createProjectsCommand(): Command {
   const projects = new Command('projects');
 
@@ -157,67 +158,6 @@ export function createProjectsCommand(): Command {
   return projects;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/commands/webhooks.ts
+++ b/src/commands/webhooks.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { GateKit } from '@gatekit/sdk';
 import { loadConfig, formatOutput, handleError } from '../lib/utils';
 
+
 export function createWebhooksCommand(): Command {
   const webhooks = new Command('webhooks');
 
@@ -195,67 +196,6 @@ export function createWebhooksCommand(): Command {
   return webhooks;
 }
 
-
-// Target pattern parsing helpers
-function parseTargetPattern(pattern: string): { platformId: string; type: string; id: string } {
-  const parts = pattern.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
-  }
-
-  const [platformId, type, id] = parts;
-
-  if (!['user', 'channel', 'group'].includes(type)) {
-    throw new Error('Invalid target type. Must be: user, channel, or group');
-  }
-
-  return { platformId, type, id };
-}
-
-function parseTargetsPattern(pattern: string): Array<{ platformId: string; type: string; id: string }> {
-  const patterns = pattern.split(',').map(p => p.trim());
-  return patterns.map(parseTargetPattern);
-}
-
-function buildMessageDto(options: any): any {
-  const dto: any = {};
-
-  // Handle targets - priority: targets pattern > target pattern > content object
-  if (options.targets) {
-    dto.targets = parseTargetsPattern(options.targets);
-  } else if (options.target) {
-    dto.targets = [parseTargetPattern(options.target)];
-  }
-
-  // Handle content - priority: text shortcut > content object
-  if (options.text) {
-    dto.content = { text: options.text };
-  } else if (options.content) {
-    try {
-      dto.content = JSON.parse(options.content);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  // Handle optional fields with error handling
-  if (options.options) {
-    try {
-      dto.options = JSON.parse(options.options);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  if (options.metadata) {
-    try {
-      dto.metadata = JSON.parse(options.metadata);
-    } catch (e) {
-      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-
-  return dto;
-}
 
 async function checkPermissions(config: any, requiredScopes: string[]): Promise<boolean> {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const program = new Command();
 program
   .name('gatekit')
   .description('GateKit Universal Messaging Gateway CLI')
-  .version('1.2.2');
+  .version('1.3.0');
 
 // Config command
 const config = new Command('config');

--- a/src/lib/message-utils.ts
+++ b/src/lib/message-utils.ts
@@ -1,0 +1,171 @@
+// Message parsing utilities for GateKit CLI
+// Auto-generated - DO NOT EDIT
+
+// Platform options schema (for array detection and object types)
+interface PropertySchema {
+  type: string;
+  description?: string;
+  format?: string;
+  items?: { type: string; format?: string };
+}
+
+const PLATFORM_SCHEMAS: Record<string, Record<string, PropertySchema>> = {
+  "email": {
+    "cc": {
+      "type": "array",
+      "description": "CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email",
+      "items": {
+        "type": "string",
+        "format": "email"
+      }
+    },
+    "bcc": {
+      "type": "array",
+      "description": "BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing",
+      "items": {
+        "type": "string",
+        "format": "email"
+      }
+    },
+    "replyTo": {
+      "type": "string",
+      "description": "Reply-To address Email address where replies should be sent (different from sender)",
+      "format": "email"
+    },
+    "headers": {
+      "type": "object",
+      "description": "Custom SMTP headers Advanced: Add custom headers to the email"
+    }
+  }
+};
+
+// Target pattern parsing helpers
+export interface TargetPattern {
+  platformId: string;
+  type: string;
+  id: string;
+}
+
+export function parseTargetPattern(pattern: string): TargetPattern {
+  const parts = pattern.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid target pattern. Expected format: platformId:type:id');
+  }
+
+  const [platformId, type, id] = parts;
+
+  if (!['user', 'channel', 'group'].includes(type)) {
+    throw new Error('Invalid target type. Must be: user, channel, or group');
+  }
+
+  return { platformId, type, id };
+}
+
+export function parseTargetsPattern(pattern: string): TargetPattern[] {
+  const patterns = pattern.split(',').map(p => p.trim());
+  return patterns.map(parseTargetPattern);
+}
+
+interface MessageOptions {
+  targets?: string;
+  target?: string;
+  text?: string;
+  content?: string;
+  options?: string;
+  metadata?: string;
+  [key: string]: unknown; // For platform-specific options
+}
+
+interface MessageDto {
+  targets?: TargetPattern[];
+  content?: Record<string, unknown>;
+  options?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export function buildMessageDto(options: MessageOptions): any {
+  const dto: MessageDto = {};
+
+  // Handle targets - priority: targets pattern > target pattern > content object
+  if (options.targets) {
+    dto.targets = parseTargetsPattern(options.targets);
+  } else if (options.target) {
+    dto.targets = [parseTargetPattern(options.target)];
+  }
+
+  // Handle content - priority: text shortcut > content object
+  if (options.text) {
+    dto.content = { text: options.text };
+  } else if (options.content) {
+    try {
+      dto.content = JSON.parse(options.content);
+    } catch (e) {
+      throw new Error(`Invalid JSON for --content: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Parse platform-specific options from dotted flags (e.g., --email.cc)
+  const platformOptions = parsePlatformOptions(options);
+  if (platformOptions) {
+    dto.content = dto.content || {};
+    dto.content.platformOptions = platformOptions;
+  }
+
+  // Handle optional fields with error handling
+  if (options.options) {
+    try {
+      dto.options = JSON.parse(options.options);
+    } catch (e) {
+      throw new Error(`Invalid JSON for --options: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  if (options.metadata) {
+    try {
+      dto.metadata = JSON.parse(options.metadata);
+    } catch (e) {
+      throw new Error(`Invalid JSON for --metadata: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return dto;
+}
+
+function parsePlatformOptions(options: MessageOptions): Record<string, Record<string, unknown>> | undefined {
+  const platformOptions: Record<string, Record<string, unknown>> = {};
+
+  // Find all dotted options (e.g., email.cc, email.bcc)
+  for (const [key, value] of Object.entries(options)) {
+    if (typeof key === 'string' && key.includes('.')) {
+      const [platform, prop] = key.split('.');
+
+      if (!platformOptions[platform]) {
+        platformOptions[platform] = {};
+      }
+
+      // Get schema for this property to determine type
+      const propSchema = PLATFORM_SCHEMAS[platform]?.[prop];
+
+      if (propSchema?.type === 'object') {
+        // Handle object types (like headers: Record<string, string>)
+        try {
+          platformOptions[platform][prop] = JSON.parse(value as string);
+        } catch (e) {
+          throw new Error(`Invalid JSON for --${platform}.${prop}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      } else if (propSchema?.type === 'array') {
+        // Handle array types (split on comma)
+        if (typeof value === 'string' && value.includes(',')) {
+          platformOptions[platform][prop] = value.split(',').map((v: string) => v.trim());
+        } else {
+          // Single value becomes single-element array
+          platformOptions[platform][prop] = [value];
+        }
+      } else {
+        // Handle scalar types (string, number, boolean)
+        platformOptions[platform][prop] = value;
+      }
+    }
+  }
+
+  return Object.keys(platformOptions).length > 0 ? platformOptions : undefined;
+}


### PR DESCRIPTION
## Summary

Adds authentication commands (, ) and email platform options support to the CLI package.

**Version**: v1.3.0
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New authentication commands**:
  -  - Create new user account (first user becomes admin)
  -  - Login with email and password
  - Updated  documentation and usage

- **Email platform options support**:
  - Added  flag for CC recipients
  - Added  flag for BCC recipients  
  - Added  flag for reply-to address
  - Added  flag for custom SMTP headers

- **Code improvements**:
  - Extracted message parsing utilities to 
  - Removed duplicate code across command files
  - Added test script placeholder
  - Version bump from 1.2.2 to 1.3.0

### Usage Examples


