### PR TITLE
Fix webhook events array handling in CLI commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official CLI for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/webhooks.ts
+++ b/src/commands/webhooks.ts
@@ -34,7 +34,7 @@ export function createWebhooksCommand(): Command {
         const result = await gk.webhooks.create({
       name: options.name,
       url: options.url,
-      events: options.events,
+      events: options.events ? (typeof options.events === 'string' ? options.events.split(',').map((v: string) => v.trim()) : options.events) : undefined,
       secret: options.secret,
       project: options.project || config.defaultProject
         });
@@ -124,7 +124,7 @@ export function createWebhooksCommand(): Command {
         const result = await gk.webhooks.update(options.webhookId, {
       name: options.name,
       url: options.url,
-      events: options.events,
+      events: options.events ? (typeof options.events === 'string' ? options.events.split(',').map((v: string) => v.trim()) : options.events) : undefined,
       isActive: options.isActive !== undefined ? (options.isActive === 'true' || options.isActive === true) : undefined,
       project: options.project || config.defaultProject
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const program = new Command();
 program
   .name('gatekit')
   .description('GateKit Universal Messaging Gateway CLI')
-  .version('1.3.0');
+  .version('1.3.1');
 
 // Config command
 const config = new Command('config');


### PR DESCRIPTION
## Summary

Fixed webhook events parameter handling to properly parse comma-separated strings into arrays for webhook create and update commands.

**Version**: v1.3.1
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **Fixed webhook events parsing**: The  flag now properly handles comma-separated strings by splitting them into arrays
- **Improved type safety**: Added string type checking before attempting to split events parameter  
- **Updated version**: Bumped from 1.3.0 to 1.3.1

