### PR TITLE
Add user invitation and password management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ gatekit auth signup --email admin@example.com --password Admin123 --name "Admin 
 gatekit auth login --email admin@example.com --password Admin123
 ```
 
-### Get current authentication context and permissions
+### Accept a project invitation and create account
 ```bash
-gatekit auth whoami
+gatekit auth accept-invite --token abc123... --name "John Doe" --password SecurePass123
 ```
 
 ## Identities
@@ -141,9 +141,9 @@ gatekit messages list
 gatekit messages stats
 ```
 
-### Get a specific message by ID
+### List sent messages for a project
 ```bash
-gatekit messages get --messageId "msg-123"
+gatekit messages sent
 ```
 
 ## Platform Logs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatekit/cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Official CLI for GateKit universal messaging gateway",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -64,6 +64,34 @@ export function createAuthCommand(): Command {
     });
 
   auth
+    .command('accept-invite')
+    .description('Accept a project invitation and create account')
+    .option('--token <value>', 'Invite token from invitation link')
+    .option('--name <value>', 'Full name')
+    .option('--password <value>', 'Password (min 8 chars, 1 uppercase, 1 number)')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await loadConfig();
+
+        // Check permissions
+        // No permissions required for this command
+
+        const gk = new GateKit(config);
+
+        const result = await gk.auth.acceptInvite({
+      token: options.token,
+      name: options.name,
+      password: options.password
+        });
+
+        formatOutput(result, options.json);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  auth
     .command('whoami')
     .description('Get current authentication context and permissions')
 
@@ -78,6 +106,32 @@ export function createAuthCommand(): Command {
         const gk = new GateKit(config);
 
         const result = await gk.auth.whoami();
+
+        formatOutput(result, options.json);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  auth
+    .command('update-password')
+    .description('Update your password (requires current password)')
+    .option('--currentPassword <value>', 'Current password')
+    .option('--newPassword <value>', 'New password (min 8 chars, 1 uppercase, 1 number)')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await loadConfig();
+
+        // Check permissions
+        // No permissions required for this command
+
+        const gk = new GateKit(config);
+
+        const result = await gk.auth.updatePassword({
+      currentPassword: options.currentPassword,
+      newPassword: options.newPassword
+        });
 
         formatOutput(result, options.json);
       } catch (error) {

--- a/src/commands/members.ts
+++ b/src/commands/members.ts
@@ -125,6 +125,36 @@ export function createMembersCommand(): Command {
       }
     });
 
+  members
+    .command('invite')
+    .description('Invite a user to join a project')
+    .option('--email <value>', 'Email address of user to invite')
+    .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await loadConfig();
+
+        // Check permissions
+        const hasPermission = await checkPermissions(config, ["members:write"]);
+        if (!hasPermission) {
+          console.error('❌ Insufficient permissions. Required: members:write');
+          process.exit(1);
+        }
+
+        const gk = new GateKit(config);
+
+        const result = await gk.members.invite({
+      email: options.email,
+      project: options.project || config.defaultProject
+        });
+
+        formatOutput(result, options.json);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
   return members;
 }
 

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -94,6 +94,40 @@ export function createMessagesCommand(): Command {
     });
 
   messages
+    .command('sent')
+    .description('List sent messages for a project')
+    .option('--platform <value>', 'Filter by platform')
+    .option('--status <value>', 'Filter by status (pending, sent, failed)')
+    .option('--limit <value>', 'Number of messages to return', '50')
+    .option('--offset <value>', 'Number of messages to skip', '0')
+    .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
+    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
+    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
+    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
+    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const config = await loadConfig();
+
+        // Check permissions
+        const hasPermission = await checkPermissions(config, ["messages:read"]);
+        if (!hasPermission) {
+          console.error('❌ Insufficient permissions. Required: messages:read');
+          process.exit(1);
+        }
+
+        const gk = new GateKit(config);
+
+        const result = await gk.messages.sent({ project: options.project || config.defaultProject });
+
+        formatOutput(result, options.json);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  messages
     .command('get')
     .description('Get a specific message by ID')
     .option('--messageId <value>', 'Message ID')
@@ -246,40 +280,6 @@ export function createMessagesCommand(): Command {
         const gk = new GateKit(config);
 
         const result = await gk.messages.retry(options.jobId, { project: options.project || config.defaultProject });
-
-        formatOutput(result, options.json);
-      } catch (error) {
-        handleError(error);
-      }
-    });
-
-  messages
-    .command('sent')
-    .description('List sent messages for a project')
-    .option('--platform <value>', 'Filter by platform')
-    .option('--status <value>', 'Filter by status (pending, sent, failed)')
-    .option('--limit <value>', 'Number of messages to return', '50')
-    .option('--offset <value>', 'Number of messages to skip', '0')
-    .option('--project <value>', 'Project (uses GATEKIT_DEFAULT_PROJECT if not provided)')
-    .option('--email.cc <value>', '[Email (SMTP)] CC recipients (Carbon Copy) Multiple recipients who will receive a copy of the email')
-    .option('--email.bcc <value>', '[Email (SMTP)] BCC recipients (Blind Carbon Copy) Multiple recipients who will receive a copy without others knowing')
-    .option('--email.replyTo <value>', '[Email (SMTP)] Reply-To address Email address where replies should be sent (different from sender)')
-    .option('--email.headers <value>', '[Email (SMTP)] Custom SMTP headers Advanced: Add custom headers to the email')
-    .option('--json', 'Output as JSON')
-    .action(async (options) => {
-      try {
-        const config = await loadConfig();
-
-        // Check permissions
-        const hasPermission = await checkPermissions(config, ["messages:read"]);
-        if (!hasPermission) {
-          console.error('❌ Insufficient permissions. Required: messages:read');
-          process.exit(1);
-        }
-
-        const gk = new GateKit(config);
-
-        const result = await gk.messages.sent({ project: options.project || config.defaultProject });
 
         formatOutput(result, options.json);
       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const program = new Command();
 program
   .name('gatekit')
   .description('GateKit Universal Messaging Gateway CLI')
-  .version('1.3.1');
+  .version('1.3.2');
 
 // Config command
 const config = new Command('config');


### PR DESCRIPTION
## Summary

Added user invitation system and password management capabilities to the CLI, along with command reorganization and version bump.

**Version**: v1.3.2
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

**New Authentication Commands:**
-  - Accept project invitations and create accounts
-  - Update user passwords with current password verification

**New Member Management:**
-  - Invite users to join projects via email

**Command Reorganization:**
- Moved  command to better position in command list
- Updated README examples to reflect new invitation workflow

**Version Update:**
- Bumped from v1.3.1 to v1.3.2

### Usage Examples


